### PR TITLE
Fix deprecated Meteor.addCollectionProtype

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1,4 +1,4 @@
-Meteor.addCollectionPrototype('syncAlgolia', function(algoliaIndex, options) {
+CollectionExtensions.addPrototype('syncAlgolia', function(algoliaIndex, options) {
 
   options = options || {};
   var Collection = this;
@@ -35,7 +35,7 @@ Meteor.addCollectionPrototype('syncAlgolia', function(algoliaIndex, options) {
 
 });
 
-Meteor.addCollectionPrototype('initAlgolia', function(algoliaIndex, options) {
+CollectionExtensions.addPrototype('initAlgolia', function(algoliaIndex, options) {
 
   options = options || {};
   var Collection = this;


### PR DESCRIPTION
With the new Meteor 1.4.2 we get a warning for the usage of Meteor.addCollectionPrototype (`Meteor.addCollectionPrototype` is deprecated, please use `CollectionExtensions.addPrototype`).

This pull request changes it to CollectionExtensions.addPrototype.
